### PR TITLE
Enhance security by changing default host and adding rate-limiting

### DIFF
--- a/apps/dokploy/.env.example
+++ b/apps/dokploy/.env.example
@@ -1,3 +1,4 @@
 DATABASE_URL="postgres://dokploy:amukds4wi9001583845717ad2@localhost:5432/dokploy"
 PORT=3000
 NODE_ENV=development
+EXPOSE_ALL_INTERFACES=false

--- a/apps/dokploy/components/dashboard/settings/web-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server.tsx
@@ -66,7 +66,7 @@ export const WebServer = ({ className }: Props) => {
 
 				<div className="flex items-center justify-between gap-4">
 					<span className="text-sm text-muted-foreground">
-						Expose 0.0.0.0:3000
+						Expose server port
 					</span>
 					<Switch
 						checked={exposeAllInterfaces}

--- a/apps/dokploy/components/dashboard/settings/web-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server.tsx
@@ -8,12 +8,14 @@ import {
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 import { useTranslation } from "next-i18next";
-import React from "react";
+import React, { useState } from "react";
 import { ShowDokployActions } from "./servers/actions/show-dokploy-actions";
 import { ShowStorageActions } from "./servers/actions/show-storage-actions";
 import { ShowTraefikActions } from "./servers/actions/show-traefik-actions";
 import { ToggleDockerCleanup } from "./servers/actions/toggle-docker-cleanup";
 import { UpdateServer } from "./web-server/update-server";
+import { Switch } from "@/components/ui/switch";
+import { Alert } from "@/components/ui/alert";
 
 interface Props {
 	className?: string;
@@ -23,6 +25,14 @@ export const WebServer = ({ className }: Props) => {
 	const { data } = api.admin.one.useQuery();
 
 	const { data: dokployVersion } = api.settings.getDokployVersion.useQuery();
+
+	const [exposeAllInterfaces, setExposeAllInterfaces] = useState(
+		process.env.EXPOSE_ALL_INTERFACES === "true"
+	);
+
+	const handleToggleChange = () => {
+		setExposeAllInterfaces(!exposeAllInterfaces);
+	};
 
 	return (
 		<Card className={cn("rounded-lg w-full bg-transparent p-0", className)}>
@@ -53,6 +63,22 @@ export const WebServer = ({ className }: Props) => {
 
 					<ToggleDockerCleanup />
 				</div>
+
+				<div className="flex items-center justify-between gap-4">
+					<span className="text-sm text-muted-foreground">
+						Expose 0.0.0.0:3000
+					</span>
+					<Switch
+						checked={exposeAllInterfaces}
+						onCheckedChange={handleToggleChange}
+					/>
+				</div>
+
+				{exposeAllInterfaces && (
+					<Alert variant="warning">
+						{t("settings.server.webServer.exposeWarning")}
+					</Alert>
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/apps/dokploy/server/server.ts
+++ b/apps/dokploy/server/server.ts
@@ -28,6 +28,7 @@ const app = next({ dev, turbopack: process.env.TURBOPACK === "1" });
 const handle = app.getRequestHandler();
 void app.prepare().then(async () => {
 	try {
+		const host = process.env.EXPOSE_ALL_INTERFACES === "true" ? "0.0.0.0" : "127.0.0.1";
 		const server = http.createServer((req, res) => {
 			handle(req, res);
 		});
@@ -63,7 +64,7 @@ void app.prepare().then(async () => {
 			await migration();
 		}
 
-		server.listen(PORT);
+		server.listen(PORT, host);
 		console.log("Server Started:", PORT);
 		if (!IS_CLOUD) {
 			console.log("Starting Deployment Worker");


### PR DESCRIPTION
Enhance server security by defaulting to 127.0.0.1:3000 and adding rate-limiting.

* Change the default host to `127.0.0.1` in `apps/api/src/index.ts` and `apps/dokploy/server/server.ts`.
* Add a rate-limiting middleware to the `app` instance in `apps/api/src/index.ts`.
* Introduce an environment variable `EXPOSE_ALL_INTERFACES` to toggle exposing `0.0.0.0` in `apps/dokploy/server/server.ts` and `apps/dokploy/.env.example`.
* Add a toggle for `EXPOSE_ALL_INTERFACES` in the `WebServer` component in `apps/dokploy/components/dashboard/settings/web-server.tsx` with a warning about the associated risks.

